### PR TITLE
Clarify RFC approval details in README

### DIFF
--- a/rfc/README.md
+++ b/rfc/README.md
@@ -63,7 +63,7 @@ The Primary Author is responsible and accountable for the majority of the activi
 * Soliciting participation in the RFC via announcement in relevant channels and discussions.
 * Ensuring all comments are appropriately addressed and when appropriately addressed, that they are subsequently resolved in the PR.
 * Enforcing adherence to the stipulated timeline(s) for the RFC, including enforcement of the Commenting Period.
-* On conclusion of the RFC, after approval[1] from at least one of the registered `CODEOWNERS` of the RFC subsequently merging the PR into the `main` branch.
+* On conclusion of the RFC, after approval[^1] from at least one of the registered `CODEOWNERS` of the RFC subsequently merging the PR into the `main` branch.
 
 The Primary Author has the prerogative to ignore, discard, or include comments that were registered outside the stated Commenting Period, into the record.
 
@@ -101,4 +101,4 @@ An RFC may 'graduate', potentially in combination with other RFCs, into an ADR. 
 
 ## Footnotes
 
-* [1]: Note that this approval is _not an approval of the content_ of the RFC, but instead _reflects approval that the process was followed_ as outlined in this document.
+[^1]: Note that this approval is _not an approval of the content_ of the RFC, but instead _reflects approval that the process was followed_ as outlined in this document.

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -32,7 +32,7 @@ An RFC's lifecycle is managed through the GitHub Pull Request process and via th
     * Update the Comment Deadline in the RFC document to an appropriate deadline. 30 days from when the RFC is moved into the "Ready" state is recommended.
 1. Collect comments via the Pull Request (see also [How do I comment on an RFC](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request)) until the Comment Deadline.
 1. Address and resolve every comment, all comments must be resolved before the Pull Request can be merged into `main`, to be sure everyone's contributions have been acknoledged and (possibly) incorportated. Every comment must receive a response by the author(s) in accordance with [addressing comments](#addressing-comments).
-1. Once all comments are resolved and the comment deadline is reached, the `CODEOWNERS` will approve the PR and it will become mergeable. The Primary Author merges the RFC into the `main` branch, thereby completing the RFC.
+1. Once all comments are resolved and the comment deadline is reached, the `CODEOWNERS` will approve the Pull Request and it will become mergeable. The Primary Author merges the RFC into the `main` branch, thereby completing the RFC.
 
 Upon finalization of the RFC, if further discussion should be needed, then a new RFC must be created to facilitate this discussion.
 

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -6,7 +6,7 @@ We write an RFC to _communicate intent and get feedback_ before we start buildin
 
 Whenever your team is making a decision that could affect the platform, write the details and get feedback from others on the Platform. Anyone - including product managers, UX, research, and engineers - is encouraged to create RFCs in order to solicit ideas in preparation of a decision direction.
 
-Note that RFC approval is _not an approval of the content_ of the RFC, but instead _reflects approval that the process was followed_. You should not feel the need to _wait for approval_ before starting your work.
+Note that RFC Pull Request approval is _not an approval of the content_ of the RFC, but instead _reflects approval that the process was followed_. You should not feel the need to _wait for approval_ before starting your work.
 
 ## How do I create an RFC and manage its lifecycle?
 

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -103,4 +103,4 @@ An RFC may 'graduate', potentially in combination with other RFCs, into an ADR. 
 
 ## Footnotes
 
-[^1]: Note that this approval is _not an approval of the content_ of the RFC, but instead _reflects approval that the process was followed_ as outlined in this document.
+[^1]: Note that the Pull Request approval is  _not an approval of the content_ of the RFC, but instead _reflects approval that the process was followed_ as outlined in this document.

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -65,7 +65,7 @@ The Primary Author is responsible and accountable for the majority of the activi
 * Soliciting participation in the RFC via announcement in relevant channels and discussions.
 * Ensuring all comments are appropriately addressed and when appropriately addressed, that they are subsequently resolved in the PR.
 * Enforcing adherence to the stipulated timeline(s) for the RFC, including enforcement of the Commenting Period.
-* On conclusion of the RFC, after approval[^1] from at least one of the registered `CODEOWNERS` of the RFC subsequently merging the PR into the `main` branch.
+* On conclusion of the RFC, after the Pull Request has approval[^1] from at least one of the registered `CODEOWNERS` of the RFC subsequently merging the PR into the `main` branch.
 
 The Primary Author has the prerogative to ignore, discard, or include comments that were registered outside the stated Commenting Period, into the record.
 

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -26,12 +26,12 @@ An RFC's lifecycle is managed through the GitHub Pull Request process and via th
     * Attachment of default labels (e.g. `RFC`), these must remain in place.
     * Addition of the PR to the [Platform Architecture](https://github.com/orgs/department-of-veterans-affairs/projects/710/views/1) board in the "Draft" column.
 1. Contributing Authors:
-    * Collaborate on the RFC document in its dedicated branch until it is in a state where it can receive comments.
+    * Collaborate on the RFC document in its dedicated branch until it is in a state where it can receive comments (this can be done directly from the Pull Request by Editing the file).
 1. Primary Author:
     * When collaborators have finished updating the RFC and it is ready for public comment, move the RFC from the "Draft" column to "Ready" on the [Platform Architecture project board](https://github.com/orgs/department-of-veterans-affairs/projects/710/views/1).
     * Update the Comment Deadline in the RFC document to an appropriate deadline. 30 days from when the RFC is moved into the "Ready" state is recommended.
 1. Collect comments via the Pull Request (see also [How do I comment on an RFC](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request)) until the Comment Deadline.
-1. Address and resolve every comment, all comments must be resolved before the Pull Request can be merged into `main`, to be sure everyone's contributions have been acknoledged and (possibly) incorportated. Every comment must receive a response by the author(s) in accordance with [addressing comments](#addressing-comments).
+1. Address and resolve every comment, all comments must be resolved before the Pull Request can be merged into `main`, to be sure everyone's contributions have been acknowledged and (possibly) incorportated. Every comment must receive a response by the author(s) in accordance with [addressing comments](#addressing-comments).
 1. Once all comments are resolved and the comment deadline is reached, the `CODEOWNERS` will approve the Pull Request and it will become mergeable. The Primary Author merges the RFC into the `main` branch, thereby completing the RFC.
 
 Upon finalization of the RFC, if further discussion should be needed, then a new RFC must be created to facilitate this discussion.

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -6,6 +6,8 @@ We write an RFC to _communicate intent and get feedback_ before we start buildin
 
 Whenever your team is making a decision that could affect the platform, write the details and get feedback from others on the Platform. Anyone - including product managers, UX, research, and engineers - is encouraged to create RFCs in order to solicit ideas in preparation of a decision direction.
 
+Note that RFC approval is _not an approval of the content_ of the RFC, but instead _reflects approval that the process was followed_. You should not feel the need to _wait for approval_ before starting your work.
+
 ## How do I create an RFC and manage its lifecycle?
 
 An RFC's lifecycle is managed through the GitHub Pull Request process and via these outlined, ordered steps:
@@ -29,7 +31,7 @@ An RFC's lifecycle is managed through the GitHub Pull Request process and via th
     * When collaborators have finished updating the RFC and it is ready for public comment, move the RFC from the "Draft" column to "Ready" on the [Platform Architecture project board](https://github.com/orgs/department-of-veterans-affairs/projects/710/views/1).
     * Update the Comment Deadline in the RFC document to an appropriate deadline. 30 days from when the RFC is moved into the "Ready" state is recommended.
 1. Collect comments via the Pull Request (see also [How do I comment on an RFC](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request)) until the Comment Deadline.
-1. Address and resolve every comment, all comments must be resolved before the Pull Request can be merged into `main`. Every comment must receive a response by the author(s) in accordance with [addressing comments](#addressing-comments).
+1. Address and resolve every comment, all comments must be resolved before the Pull Request can be merged into `main`, to be sure everyone's contributions have been acknoledged and (possibly) incorportated. Every comment must receive a response by the author(s) in accordance with [addressing comments](#addressing-comments).
 1. Once all comments are resolved and the comment deadline is reached, the `CODEOWNERS` will approve the PR and it will become mergeable. The Primary Author merges the RFC into the `main` branch, thereby completing the RFC.
 
 Upon finalization of the RFC, if further discussion should be needed, then a new RFC must be created to facilitate this discussion.


### PR DESCRIPTION
There has been some confusion about how/why RFCs need to be "approved", and what that means. And also around the 30-day comment period, and does that work should not begin until "approval". I hope these changes (more clarifications are welcome!) make things easier to understand and underscore an RFC more as a tool and less as a process.