### PR TITLE
Updating the RFC labeling instruction to exclude rfc/README.md

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,3 +2,4 @@
 # Used by https://github.com/department-of-veterans-affairs/va.gov-platform-architecture/blob/main/.github/workflows/pull_request_labeler.yml
 RFC:
 - rfc/**/*
+- '!rfc/README.md'


### PR DESCRIPTION
Whenever the `rfc/README.md` file is touched, the labeler zealously attach the `RFC` label. We do not want this to happen as that file is not an RFC and will (typically) be touched outside of an RFC-related workflow.