### PR TITLE
Add action to run an "open RFC report" on a schedule

### DIFF
--- a/.github/workflows/rfc_report.yml
+++ b/.github/workflows/rfc_report.yml
@@ -24,5 +24,5 @@ jobs:
               "message_text": "${{ steps.list_rfcs.outputs.pulls }}"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RFC_REPORT_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/rfc_report.yml
+++ b/.github/workflows/rfc_report.yml
@@ -1,0 +1,28 @@
+name: "RFC Report"
+on:
+  schedule:
+    - cron: '0 9 * * 1,4'  # Mon, Thurs 9am
+  workflow_dispatch:
+jobs:
+  rfc_report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: List all RFC pull requests
+        uses: buildsville/list-pull-requests@v1
+        id: list_rfcs
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          labels: '["RFC"]'
+          skip_hour: '0' # do not filter by create date
+      - name: Send message to Slack workflow
+        uses: slackapi/slack-github-action@v1.18.0
+        id: slack_workflow
+        with:
+          payload: |
+            {
+              "text": "this field is unused but required",
+              "message_text": "${{ steps.list_rfcs.outputs.pulls }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
This workflow runs twice a week. It gathers open RFCs, and sends the list to a DSVA slack workflow ("Open RFC Report") that displays the text in a channel.

Currently set to run on Monday and Thursday mornings, and send the message to channel #dev_null.

Once merged, I'll trigger the workflow as a test, ensure the message is coming out properly in #dev_null, then we can modify the workflow to post to #platform-team. We can also set an icon and tweak the text surrounding the list of RFCs.

Slack message will look similar to this (PR title, url):
<img width="336" alt="image" src="https://user-images.githubusercontent.com/7627/180821969-c89c8cc7-8cc8-45ef-81b7-dd7b4f68bab8.png">
