### PR TITLE
RFC: CIT Hostname Transition Plan

### DIFF
--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -57,7 +57,7 @@ The vets-api code base makes several API requests to different hosts. In instanc
 #### **Vets-api: Settings**
 The vets-api settings in the devops repository which reference `api.va.gov` have been identified and their change requirements have been documented.
 
-Reference: [Vets-api Re-mapped Settings](https://docs.google.com/spreadsheets/d/111t6f4V3eCVkaKoBIxXi54_HlkPT-54qKShfRjl-iMs/edit#gid=2101280441).
+Reference: [Vets-api Re-mapped Settings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/f3389a1a1aed15d54f9f0f2580f6c2ea188cf9e8/platform/engineering/infrastructure/vets_api_upstream_settings.xlsx).
 
 With the exception of the authentication callbacks that will need to change to the new, environment-specific *platform-api.va.gov hostnames, all settings that required changes have been updated and tested with the help of affected teams. See **Release Steps** for details on updating authentication callbacks.
 
@@ -249,12 +249,12 @@ At this time the Lighthouse team is working to transition to using the new Apige
 
 
 ## **Appendix**
-  - [Hostname Transition Story Map](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2334687528/Hostname+Transition+Story+Map+-+Cloud+Isolation) (Confluence)
+  - [Hostname Transition Story Map](https://github.com/department-of-veterans-affairs/va.gov-team/blob/f3389a1a1aed15d54f9f0f2580f6c2ea188cf9e8/platform/engineering/infrastructure/hostname_release_story_map.xlsx) (Excel File)
   - [Forward Proxy Addresses](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263449831/Guide+API+Hostname+Status) (Confluence)
   - [Hostname Specifications](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2283339976) (Confluence)
   - [Reroute vets-api upstream requests to Lighthouse](https://vfs.atlassian.net/wiki/spaces/ECP/pages/2220785993/2022-06-06+Reroute+vets-api+upstream+requests+to+Lighthouse) (ADR/Confluence)
   - [Datadog Tests](https://vagov.ddog-gov.com/synthetics/tests?query=tag%3A%28%22team%3Acit%22%29) (Datadog Link)
-  - [Remapped vets-api settings](https://docs.google.com/spreadsheets/d/111t6f4V3eCVkaKoBIxXi54_HlkPT-54qKShfRjl-iMs/edit#gid=2101280441) (Google Sheet)
+  - [Remapped vets-api settings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/f3389a1a1aed15d54f9f0f2580f6c2ea188cf9e8/platform/engineering/infrastructure/vets_api_upstream_settings.xlsx) (Excel File)
   - [Enabling new *platform-api.va.gov domains in EKS](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263351375) (Confluence)
   - [New Domain to Serve vets-api](https://vfs.atlassian.net/wiki/spaces/ECP/pages/2221572288/2022-06-06+New+domain+to+serve+vets-api) (ADR/Confluence)
   - [Original Explainer Doc on VA.gov <=> Lighthouse overlap](https://vfs.atlassian.net/wiki/spaces/ECP/pages/1907523684/Explainer+-+VA.gov-Lighthouse+Overlap) (Confluence)

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -116,10 +116,6 @@ To prevent the future use of *api.va.gov in test files, the Release Tools Team s
   - Adds linting rules to prevent use of the api.va.gov hostname.
 
 
-#### **GIDS (GI Bill Data Services)**
-   * Edits global `link_host` variable to use environment-specific *platform-api.va.gov value in both BRD and EKS deployment configurations.
-
-
 ### Release Steps
 Due to the interdependence of API calls made from VA.gov and authentication cookies set by vets-api, the deployment of the new *platform-api.va.gov hostname will require the coordinated releases of vets-api and vets-website. 
 
@@ -203,6 +199,8 @@ Because the Mobile Flagship App is not bound by the same authentication workflow
   - The global configuration variables for new versions of the Mobile Flagship app are edited to use *platform-api.va.gov hostname. 
   - The global configuration variables for older versions of the Mobile Flagship app will continue to use the api.va.gov hostname and will be routed via the Lighthouse gateway.
 
+#### **GIDS (GI Bill Data Services)**
+   * Edits global `link_host` variable to use environment-specific *platform-api.va.gov value in both BRD and EKS deployment configurations.
 
 #### **Lighthouse**
 At this time the Lighthouse team is working to transition to using the new Apigee Gateway (timeline TBD.) Until that time, Kong will continue to serve as its API gateway and will honor requests to `api.va.gov/services/*` and `api.va.gov/internal/*`.

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -186,12 +186,12 @@ All systems will need to be deployed and tested in Staging prior to a Production
 #### **Mobile Flagship App**
 Because the Mobile Flagship App is not bound by the same authentication workflows as vets-api and vets-website, it can be deployed separately.
   - The global configuration variables for new versions of the Mobile Flagship app are edited to use *platform-api.va.gov hostname. 
-  - The global configuration variables for legacy versions of the Mobile Flagship app will continue to use the older api.va.gov hostname and will be routed via the Lighthouse gateway.
+  - The global configuration variables for older versions of the Mobile Flagship app will continue to use the api.va.gov hostname and will be routed via the Lighthouse gateway.
 
 
 #### **Lighthouse**
 At this time the Lighthouse team is working to transition to using the new Apigee Gateway (timeline TBD.) Until that time, Kong will continue to serve as its API gateway and will honor requests to `api.va.gov/services/*` and `api.va.gov/internal/*`.
-  - Once implemented, the new Apigee gateway will continue to honor legacy/mobile app requests to `api.va.gov/mobile/*`.
+  - Once implemented, the new Apigee gateway will continue to honor requests to `api.va.gov/mobile/*` from older versions of the Mobile Flagship app.
   - Once implemented, the new Apigee gateway will continue to honor requests to `api.va.gov/vanotify` and route them to the  VANotify service until that team agrees to retire the endpoint.
 
 
@@ -199,7 +199,7 @@ At this time the Lighthouse team is working to transition to using the new Apige
   - Removes api.va.gov references from the revProxy. This should only happen once Apigee has been successfully set up as a new API gateway and fully owns the api.va.gov domains.
   - While the revProxy still handles the api.va.gov domain, ensures that new rules added to the `nginx_api_server.conf` file get replicated in `ngix_new_api_server.conf`.
   - Prevents new references to api.va.gov to be added to the vets-api config files `*-settings.local.yml.j2` and their EKS counterparts. 
-  - **Note:** At this time only the Dev website is in EKS. As other environments migrate to EKS, routing configurations will need to be updated and release timing will need to be re-evaluated.
+  - **Note:** At this time only the Dev website is in EKS. As other environments migrate to EKS, routing configurations will need to be updated.
 
     Reference: [Enabling new *platform-api.va.gov domains in EKS](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263351375).
   - Schedule annual TLS/SSL cert renewals for all platform-api subdomains.

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -195,6 +195,7 @@ All systems will need to be deployed and tested in Staging prior to a Production
 
 #### **Console Services**
   - Adds linting rules or triggered Github action to prevent use of the *api.va.gov hostname.
+  - Work with individual teams whose API calls were re-routed via the forward proxy to ensure that any subsequent calls, e.g. for paginated requests, are also routed in the same way (see note under **Vets-api: Settings**)
 
 
 #### **Mobile Flagship App**
@@ -231,6 +232,7 @@ At this time the Lighthouse team is working to transition to using the new Apige
     - Reduces complexity in Post-Release issue resolution.
   - **Staging downtime:** A window of time will be required to allow teams to test and mitigate any unforeseen issues. Authentication flows and day-to-day development tasks may be interrupted.
   - **Production downtime:** There may be a short period of downtime or instability in authentication flows.
+  - **Unidentified vets-api clients:** While we believe that the VA.gov website and the mobile app are the only clients of vets-api, any unidentified client would encounter 404 errors after the Apigee migration. To ward against that possibility, the Infrastructure Team could conduct a thorough examination of the revproxy logs to identify client IP addresses involved in vets-api requests that did not originate from either VA.gov or the mobile app.
   - **Unidentified issues:** Issues that are not identified in the Staging release may affect Production.
 
 

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -95,7 +95,8 @@ To prevent the future use of *api.va.gov in test files, the Release Tools Team s
 ### Pre-Release Tasks
 
 #### **Coordination**
-While the Lighthouse team currently doesn't have 
+While the Lighthouse team currently doesn't have a fixed timeline for their migration to Apigee, we propose that the transition of VA.gov to the new hostname, platform-api.va.gov, should occur as soon as is feasible. This would ensure that the independence of VA.gov from the Lighthouse domain and infrastructure has been achieved and tested in production. 
+
   - Kickoff Meeting to discuss team roles and responsibilities:
     - Release Plan timeline.
     - Rollback plan.

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -1,0 +1,226 @@
+# Hostname Transition Release Plan
+**Cloud Isolation Team**
+  - Andrea Singh (Engineering)
+  - Alan Werner (Product)
+  - Patrick Vinograd (Contributor)
+
+Who is this document for?
+  - Platform and VFS development teams that work on the front-end of vets-website or the Mobile Flagship app.
+  - Platform and VFS development teams that work on vets-api.
+  - Lighthouse development teams that are involved in the migration of the Lighthouse API gateway. 
+
+## **Background**
+Vets-api and Lighthouse currently share the same API endpoint: api.va.gov. In the near future Lighthouse will assume exclusive control of api.va.gov and consumers of VA.gov APIs will need to transition to using a new API hostname: platform-api.va.gov. The goal of the Cloud Isolation Team is to enable this separation of concerns.
+
+## **Motivation**
+
+As their product goals and technical infrastructure diverge over time, it is no longer feasible for Lighthouse and VA.gov to share the api.va.gov hostname. In particular, Lighthouse wants to re-architect to use an Apigee API gateway hosted in Google Cloud (GCP). There's no reason for all VA.gov traffic to route through this gateway or through GCP. Because Lighthouse has a large number of API consumers, most of whom are external to VA, they have priority for continuing to use api.va.gov. VA.gov will transition to a new API hostname.
+
+### New hostname for vets-api
+Teams that use VA.gov APIs as an endpoint will need to update their application code to replace any hostname instances of `api.va.gov` with `platform-api.va.gov`.
+Teams that use Lighthouse APIs as an endpoint will not be required to change their hostname addresses.
+
+
+### Rerouting upstream requests from vets-api
+The vets-api code base makes several API requests to different hosts. In instances where the hostname is configured to be `api.va.gov`, the reference will need to change. Depending on the use case, the change will be:
+  - For upstream Lighthouse requests, the requests to *api.va.gov will be routed via specially configured ports in the Forward Proxy:
+
+     - Port 4475 routes to the respective *api.va.gov host in all environments.
+     - Port 4492 should be used in Dev and Staging to target the Lighthouse sandbox environment.
+
+       Reference: [Forward Proxy Addresses](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263449831/Guide+API+Hostname+Status).
+  - For requests that vets-api makes to itself, the endpoints need to change to the new, environment-specific *platform-api.va.gov hostname.
+  - Host references that don’t make network requests should remain unchanged.
+
+
+## **Design**
+
+### Completed Work  
+#### **New hostnames**
+  - Platform-api hostnames have been registered in the VA registry:
+    - **Dev:** dev-platform-api.va.gov
+    - **Staging:** staging-platform-api.va.gov
+    - **Sandbox:** sandbox-platform-api.va.gov
+    - **Prod:** platform-api.va.gov
+  - ESECC has been approved for all hostnames.
+  - DNS has been configured for all platform-api hostnames.
+  - Platform-api hostnames are resolving to vets-api in all environments.
+
+    Reference: [Hostname Specifications](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2283339976).
+
+
+#### **Vets-api: Settings**
+The vets-api settings in the devops repository which reference `api.va.gov` have been identified and their change requirements have been documented.
+
+Reference: [Vets-api Re-mapped Settings](https://docs.google.com/spreadsheets/d/111t6f4V3eCVkaKoBIxXi54_HlkPT-54qKShfRjl-iMs/edit#gid=2101280441).
+
+_TBD: Completed rerouting vets-api upstream requests to use the forward proxy in all environments._
+
+
+#### **Vets-api: Synthetic Tests**
+Datadog synthetics were added to test a selection of updated host address settings in vets-api.
+
+Example: The `/facilities_api/v1/va` endpoint in vets-api is used by the va.gov Facility Locator app to make an upstream request to the Lighthouse Facilities API. We are rerouting the request to use the forward proxy instead of the api.va.gov hostname. The Datadog test confirms that the vets-api endpoint returns a success response and contains the expected data elements after rerouting the upstream request via the forward proxy. (See: [Rerouting upstream requests from vets-api](https://vfs.atlassian.net/wiki/spaces/ECP/pages/2220785993/2022-06-06+Reroute+vets-api+upstream+requests+to+Lighthouse).)
+
+Reference: [Complete list of Datadog Tests](https://vagov.ddog-gov.com/synthetics/tests?query=tag%3A%28%22team%3Acit%22%29)
+
+
+#### **Vets-website: Unit and Integration Test POC**
+A POC branch was created in the vets-website repository for the purpose of updating test references from `api.va.gov` to `platform-api.va.gov`.
+Updates to the test references did not break any unit or integration tests. These references were part of canned API responses and were not used in any test assertions.
+
+Certain test references to `sandbox-api.va.gov` and `api.va.gov` did not require any changes because these reference endpoints will still be served by the Lighthouse API. **Example**: `health-care-questionnaire` application (not used in Production.)
+
+Parameterizing the API URL was done where possible. Setting the API_URL constant as an environment variable will ensure that unit specs that check for the variable value will pass before and after changing the configured API URL to the new *platform-ap.va.gov hostname.
+
+The POC branch passed all unit and integration tests.
+
+The POC branch was pushed to trigger integration/E2E tests.
+
+PR feedback was gathered from affected teams.
+
+
+### Pre-Release Tasks
+_May need to finish outstanding vets-api settings changes._
+
+#### **Coordination**
+  - Kickoff Meeting to discuss team roles and responsibilities:
+    - Release Plan timeline.
+    - Rollback plan.
+    - Downtime window.
+      - In order to minimize disruptions to Staging and Production, a coordinated release of both applications should consider the different build and deploy methods and runtimes.
+      - Based on historic runtimes, determine the optimal timing for triggering the deployment of both vets-api and vets-website so that they finish at approximately the same time.
+    - Notification strategy (including user notifications for potential login availability downtime.)
+
+
+#### **VA**
+   * Submit required notifications to the VA so that entities, .e.g., the Help Desk, are aware of the planned downtime and can plan accordingly.
+
+
+#### **Site Reliability Engineering**
+   * SRE playbooks prepared to use the *platform-api.va.gov hostname(s).
+
+
+#### **Release Tools Team**
+  - Adds linting rules to prevent use of the api.va.gov hostname.
+
+
+#### **GIDS (GI Bill Data Services)**
+   * Edits global `link_host` variable to use environment-specific *platform-api.va.gov value in both BRD and EKS deployment configurations.
+
+
+### Release Steps
+Due to the interdependencies of the API hostname’s inclusion in authentication cookies set by vets-api and API calls made from VA.gov, the deployment of the new *platform-api.va.gov hostname will require a coordinated sequence of events between vets-api and vets-website that occur at an agreed upon time.
+
+All systems will need to be deployed and tested in Staging prior to a Production deployment.
+
+
+#### **Proposed Release Sequence:**
+
+**Step 1** (Rollback preparation)
+  - Identity Team works with IAM authentication partners to prepare the rollback plan for reverting auth callback changes. 
+  - Release Tools Team prepares rollback PR and build.
+
+
+**Step 2** (Coordinated release of vets-api and vets-website repositories in lower environments)
+  - Broadcast an internal notification that Staging may be disrupted.
+  - Site Reliability Engineering notified of impending deployment to Staging.
+  - Infrastructure On-Call Team notified of impending deployment to Staging.
+  - In parallel:
+    - The Identity Team updates the vets-api authentication URLs for Dev and Staging. 
+    - The IAM team updates their own API callback URLs for Dev and Staging.
+  - Release Tools Team updates globally configured API URL for vets-website for Dev and Staging.
+  - vets-website repo:
+    - PRs merged into the main branch are automatically built and deployed to both dev and staging. 
+    - The GHA CI workflow runs. Completion time can vary, ~15 to 40 min.
+  - vets-api in Dev (EKS):
+    - Changes to the settings file are automatically deployed by ArgoCD. Completion time is fast.
+  - vets-api in Staging (BRD): 
+    - The Jenkins-led BRD cycle is triggered by PR merge to master, or manually if the change is initiated from the devops repo.
+    - The build step takes ~30 minutes, but can be run separately if needed.
+    - The deploy step is fast.
+  - Based on Pre-Release coordination research, trigger the deployment of both vets-api and vets-website so that they finish at approximately the same time. **Note**: Authentication flows may not work correctly until both applications have been fully deployed.
+
+
+
+**Step 3** (QA in Staging)
+  - Once the vets-api and vets-website Staging deployments are complete, Identity Team, Release Tools Team, and other affected front-end teams QA/UAT for issues. 
+  - Outstanding issues are fixed and re-deployed. Iterate as needed until Staging is stable.
+  - Once Staging is confirmed to be stable, prepare the Production deployment.
+
+
+**Step 4** (Coordinated release of vets-api and vets-website repositories in Production)
+  - Broadcast an internal notification that Production may be disrupted.
+  - Enable a sitewide, public-facing downtime notification informing users that Sign In will be unavailable.
+  - Site Reliability Engineering notified of impending deployment to Production.
+  - Infrastructure On-Call Team notified of impending deployment to Production.
+  - In parallel:
+    - The Identity Team prepares a PR for updates to the vets-api authentication URLs for Production.
+    - The IAM team updates the API callback URLs.
+  - Release Tools Team prepares a PR for updates to globally configured API URL for vets-website for Production.
+  - The scheduled daily auto-deploy is disabled for vets-website and vets-api so that the deployment process can be fully controlled.
+  - Identity Team manually runs only the build and release steps for vets-api.
+  - Release Tools Team triggers vets-website deploy manually. The built-in pause in the manual release will need to be approved to resume the deployment after the Build and Release steps are finished.
+  - Based on Pre-Release coordination research, trigger the deployment of both vets-api and vets-website so that they finish at approximately the same time.
+  - All teams QA/UAT Production for issues.  
+
+
+### Post-Release Tasks
+
+#### **Site Reliability Engineering**
+  - SRE playbooks updated to use the *platform-api.va.gov hostname.
+
+
+#### **Release Tools Team**
+  - Search and replace documented instances of  `api.va.gov` API references with `platform-api.va.gov`, e.g., README files, script files, code comments, etc.
+
+
+#### **Console Services**
+  - Adds linting rules or triggered Github action to prevent use of the *api.va.gov hostname.
+
+
+#### **Mobile Flagship App**
+Because the Mobile Flagship App is not bound by the same authentication workflows as vets-api and vets-website, it can be deployed separately.
+  - The global configuration variables for new versions of the Mobile Flagship app are edited to use *platform-api.va.gov hostname. 
+  - The global configuration variables for legacy versions of the Mobile Flagship app will continue to use the older api.va.gov hostname and will be routed via the Lighthouse gateway.
+
+
+#### **Lighthouse**
+At this time the Lighthouse team is working to transition to using the new Apigee Gateway (timeline TBD.) Until that time, Kong will continue to serve as its API gateway and will honor requests to `api.va.gov/services/*` and `api.va.gov/internal/*`.
+  - Once implemented, the new Apigee gateway will continue to honor legacy/mobile app requests to `api.va.gov/mobile/*`.
+  - Once implemented, the new Apigee gateway will continue to honor requests to `api.va.gov/vanotify` and route them to the  VANotify service until that team agrees to retire the endpoint.
+
+
+#### **Infrastructure Team**
+  - Removes api.va.gov references from the revProxy.
+  - At this time only the Dev website is in EKS. As other environments migrate to EKS, routing configurations will need to be updated and release timing will need to be evaluated.
+
+    Reference: [Enabling new *platform-api.va.gov domains in EKS](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263351375).
+  - Schedule annual TLS/SSL cert renewals for all platform-api subdomains.
+
+
+#### **Documentation**
+  - The Platform Content Team coordinates with contributing teams to edit documentation to use the *platform-api.va.gov hostname.
+  - The Console UI Team coordinates with contributing teams to edit documentation to use the *platform-api.va.gov hostname. Verify with CUI.
+
+
+## **Risks**
+  - **Lack of parity in environments and deployment processes:** Consideration should be given to completing the migration of all environments to EKS prior to rolling out *platform-api.va.gov.
+    - Simplifies Release Plan processes.
+    - Simplifies Post-Release issue triage.
+    - Reduces complexity in fixing issues that may arise from environments being in varying states of migration. 
+  - **Staging downtime:** A window of time will be required to allow teams to test and mitigate any unforeseen issues. Authentication flows and day-to-day development tasks may be interrupted.
+  - **Production downtime:** There may be a short period of downtime or instability in authentication flows.
+  - **Unidentified issues:** Issues that are not identified in the Staging release may affect Production.
+
+
+## **Appendix**
+  - [Forward Proxy Addresses](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263449831/Guide+API+Hostname+Status) (Confluence)
+  - [Hostname Specifications](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2283339976) (Confluence)
+  - [Reroute vets-api upstream requests to Lighthouse](https://vfs.atlassian.net/wiki/spaces/ECP/pages/2220785993/2022-06-06+Reroute+vets-api+upstream+requests+to+Lighthouse) (ADR/Confluence)
+  - [Datadog Tests](https://vagov.ddog-gov.com/synthetics/tests?query=tag%3A%28%22team%3Acit%22%29) (Datadog Link)
+  - [Remapped vets-api settings](https://docs.google.com/spreadsheets/d/111t6f4V3eCVkaKoBIxXi54_HlkPT-54qKShfRjl-iMs/edit#gid=2101280441) (Google Sheet)
+  - [Enabling new *platform-api.va.gov domains in EKS](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263351375) (Confluence)
+  - [New Domain to Serve vets-api](https://vfs.atlassian.net/wiki/spaces/ECP/pages/2221572288/2022-06-06+New+domain+to+serve+vets-api) (ADR/Confluence)
+Hostname Transition Playbook.md
+Displaying Hostname Transition Playbook.md.

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -222,5 +222,3 @@ At this time the Lighthouse team is working to transition to using the new Apige
   - [Remapped vets-api settings](https://docs.google.com/spreadsheets/d/111t6f4V3eCVkaKoBIxXi54_HlkPT-54qKShfRjl-iMs/edit#gid=2101280441) (Google Sheet)
   - [Enabling new *platform-api.va.gov domains in EKS](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263351375) (Confluence)
   - [New Domain to Serve vets-api](https://vfs.atlassian.net/wiki/spaces/ECP/pages/2221572288/2022-06-06+New+domain+to+serve+vets-api) (ADR/Confluence)
-Hostname Transition Playbook.md
-Displaying Hostname Transition Playbook.md.

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -113,7 +113,7 @@ _TBD. Outstanding vets-api settings changes._
 
 
 ### Release Steps
-Due to the interdependencies of the API hostname’s inclusion in authentication cookies set by vets-api and API calls made from VA.gov, the deployment of the new *platform-api.va.gov hostname will require a coordinated release sequence between vets-api and vets-website.
+Due to the interdependence of API calls made from VA.gov and authentication cookies set by vets-api, the deployment of the new *platform-api.va.gov hostname will require the coordinated releases of vets-api and vets-website.
 
 All systems will need to be deployed and tested in Staging prior to a Production deployment.
 
@@ -210,8 +210,7 @@ At this time the Lighthouse team is working to transition to using the new Apige
 ## **Risks**
   - **Lack of parity in environments and deployment processes:** Consideration should be given to completing the migration of all environments to EKS prior to rolling out *platform-api.va.gov.
     - Reduces complexity in Release Plan processes.
-    - Reduces complexity in Post-Release issue triage.
-    - Reduces complexity in fixing issues that may arise later if environments remain in varying states of migration. 
+    - Reduces complexity in Post-Release issue resolution.
   - **Staging downtime:** A window of time will be required to allow teams to test and mitigate any unforeseen issues. Authentication flows and day-to-day development tasks may be interrupted.
   - **Production downtime:** There may be a short period of downtime or instability in authentication flows.
   - **Unidentified issues:** Issues that are not identified in the Staging release may affect Production.

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -14,10 +14,11 @@ Vets-api and Lighthouse currently share the same API endpoint: api.va.gov. In th
 
 ## **Motivation**
 
-As their product goals and technical infrastructure diverge over time, it is no longer feasible for Lighthouse and VA.gov to share the api.va.gov hostname. In particular, Lighthouse wants to re-architect to use an Apigee API gateway hosted in Google Cloud (GCP). There's no reason for all VA.gov traffic to route through this gateway or through GCP. Because Lighthouse has a large number of API consumers, most of whom are external to VA, they have priority for continuing to use api.va.gov. VA.gov will transition to a new API hostname.
+The product goals and technical infrastructures of Lighthouse and VA.gov have diverged over time. Sharing the api.va.gov hostname is no longer feasible. In particular, Lighthouse wants to re-architect to use an Apigee API gateway hosted in Google Cloud (GCP). There's no reason for all VA.gov traffic to route through this gateway or through GCP. Because Lighthouse has a large number of API consumers, most of whom are external to VA, they have priority for continuing to use api.va.gov. VA.gov will transition to a new API hostname.
 
 ### New hostname for vets-api
 Teams that use VA.gov APIs as an endpoint will need to update their application code to replace any hostname instances of `api.va.gov` with `platform-api.va.gov`.
+
 Teams that use Lighthouse APIs as an endpoint will not be required to change their hostname addresses.
 
 
@@ -54,7 +55,7 @@ The vets-api settings in the devops repository which reference `api.va.gov` have
 
 Reference: [Vets-api Re-mapped Settings](https://docs.google.com/spreadsheets/d/111t6f4V3eCVkaKoBIxXi54_HlkPT-54qKShfRjl-iMs/edit#gid=2101280441).
 
-_TBD: Completed rerouting vets-api upstream requests to use the forward proxy in all environments._
+_TBD: Complete rerouting vets-api upstream requests to use the forward proxy in all environments._
 
 
 #### **Vets-api: Synthetic Tests**
@@ -81,24 +82,26 @@ PR feedback was gathered from affected teams.
 
 
 ### Pre-Release Tasks
-_May need to finish outstanding vets-api settings changes._
+_TBD. Outstanding vets-api settings changes._
 
 #### **Coordination**
   - Kickoff Meeting to discuss team roles and responsibilities:
     - Release Plan timeline.
     - Rollback plan.
+    - Notification strategy:
+      - Team notifications.
+      - User notifications for potential login availability.
     - Downtime window.
       - In order to minimize disruptions to Staging and Production, a coordinated release of both applications should consider the different build and deploy methods and runtimes.
       - Based on historic runtimes, determine the optimal timing for triggering the deployment of both vets-api and vets-website so that they finish at approximately the same time.
-    - Notification strategy (including user notifications for potential login availability downtime.)
 
 
 #### **VA**
-   * Submit required notifications to the VA so that entities, .e.g., the Help Desk, are aware of the planned downtime and can plan accordingly.
+   * Submit required notifications to the VA so that entities, .e.g., the Help Desk, are aware of any planned downtime or interruption of services.
 
 
 #### **Site Reliability Engineering**
-   * SRE playbooks prepared to use the *platform-api.va.gov hostname(s).
+   * SRE playbooks prepared to use the *platform-api.va.gov hostname.
 
 
 #### **Release Tools Team**
@@ -110,7 +113,7 @@ _May need to finish outstanding vets-api settings changes._
 
 
 ### Release Steps
-Due to the interdependencies of the API hostname’s inclusion in authentication cookies set by vets-api and API calls made from VA.gov, the deployment of the new *platform-api.va.gov hostname will require a coordinated sequence of events between vets-api and vets-website that occur at an agreed upon time.
+Due to the interdependencies of the API hostname’s inclusion in authentication cookies set by vets-api and API calls made from VA.gov, the deployment of the new *platform-api.va.gov hostname will require a coordinated release sequence between vets-api and vets-website.
 
 All systems will need to be deployed and tested in Staging prior to a Production deployment.
 
@@ -118,8 +121,8 @@ All systems will need to be deployed and tested in Staging prior to a Production
 #### **Proposed Release Sequence:**
 
 **Step 1** (Rollback preparation)
-  - Identity Team works with IAM authentication partners to prepare the rollback plan for reverting auth callback changes. 
-  - Release Tools Team prepares rollback PR and build.
+  - Identity Team works with IAM authentication partners to prepare a rollback plan for reverting auth callback changes. 
+  - Release Tools Team prepares a rollback PR and build.
 
 
 **Step 2** (Coordinated release of vets-api and vets-website repositories in lower environments)
@@ -193,7 +196,7 @@ At this time the Lighthouse team is working to transition to using the new Apige
 
 #### **Infrastructure Team**
   - Removes api.va.gov references from the revProxy.
-  - At this time only the Dev website is in EKS. As other environments migrate to EKS, routing configurations will need to be updated and release timing will need to be evaluated.
+  - **Note:** At this time only the Dev website is in EKS. As other environments migrate to EKS, routing configurations will need to be updated and release timing will need to be re-evaluated.
 
     Reference: [Enabling new *platform-api.va.gov domains in EKS](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263351375).
   - Schedule annual TLS/SSL cert renewals for all platform-api subdomains.
@@ -201,14 +204,14 @@ At this time the Lighthouse team is working to transition to using the new Apige
 
 #### **Documentation**
   - The Platform Content Team coordinates with contributing teams to edit documentation to use the *platform-api.va.gov hostname.
-  - The Console UI Team coordinates with contributing teams to edit documentation to use the *platform-api.va.gov hostname. Verify with CUI.
+  - The Console UI Team coordinates with contributing teams to edit documentation to use the *platform-api.va.gov hostname.
 
 
 ## **Risks**
   - **Lack of parity in environments and deployment processes:** Consideration should be given to completing the migration of all environments to EKS prior to rolling out *platform-api.va.gov.
-    - Simplifies Release Plan processes.
-    - Simplifies Post-Release issue triage.
-    - Reduces complexity in fixing issues that may arise from environments being in varying states of migration. 
+    - Reduces complexity in Release Plan processes.
+    - Reduces complexity in Post-Release issue triage.
+    - Reduces complexity in fixing issues that may arise later if environments remain in varying states of migration. 
   - **Staging downtime:** A window of time will be required to allow teams to test and mitigate any unforeseen issues. Authentication flows and day-to-day development tasks may be interrupted.
   - **Production downtime:** There may be a short period of downtime or instability in authentication flows.
   - **Unidentified issues:** Issues that are not identified in the Staging release may affect Production.

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -166,6 +166,7 @@ All systems will need to be deployed and tested in Staging prior to a Production
   - Release Tools Team triggers vets-website deploy manually. The built-in pause in the manual release will need to be approved to resume the deployment after the Build and Release steps are finished.
   - Based on Pre-Release coordination research, trigger the deployment of both vets-api and vets-website so that they finish at approximately the same time.
   - All teams QA/UAT Production for issues.  
+![staggered-deploy](https://user-images.githubusercontent.com/30317/186273089-4d101052-0166-4fde-aef5-d29214b866b2.png)
 
 
 ### Post-Release Tasks

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -249,6 +249,7 @@ At this time the Lighthouse team is working to transition to using the new Apige
 
 
 ## **Appendix**
+  - [Hostname Transition Story Map](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2334687528/Hostname+Transition+Story+Map+-+Cloud+Isolation) (Confluence)
   - [Forward Proxy Addresses](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263449831/Guide+API+Hostname+Status) (Confluence)
   - [Hostname Specifications](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2283339976) (Confluence)
   - [Reroute vets-api upstream requests to Lighthouse](https://vfs.atlassian.net/wiki/spaces/ECP/pages/2220785993/2022-06-06+Reroute+vets-api+upstream+requests+to+Lighthouse) (ADR/Confluence)

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -16,6 +16,7 @@ Vets-api and Lighthouse currently share the same API endpoint: api.va.gov. In th
 
 The product goals and technical infrastructures of Lighthouse and VA.gov have diverged over time. Sharing the api.va.gov hostname is no longer feasible. In particular, Lighthouse wants to re-architect to use an Apigee API gateway hosted in Google Cloud (GCP). There's no reason for all VA.gov traffic to route through this gateway or through GCP. Because Lighthouse has a large number of API consumers, most of whom are external to VA, they have priority for continuing to use api.va.gov. VA.gov will transition to a new API hostname.
 
+
 ### New hostname for vets-api
 Teams that use VA.gov APIs as an endpoint will need to update their application code to replace any hostname instances of `api.va.gov` with `platform-api.va.gov`.
 
@@ -69,7 +70,7 @@ Example: The `/facilities_api/v1/va` endpoint in vets-api is used by the va.gov 
 Reference: [Complete list of Datadog Tests](https://vagov.ddog-gov.com/synthetics/tests?query=tag%3A%28%22team%3Acit%22%29)
 
 
-#### **Vets-website: Change *api.va.gov References in Unit and Integration Tests**
+#### **Vets-website: Change \*api.va.gov References in Unit and Integration Tests**
 We have updated `api.va.gov` references to `platform-api.va.gov` in the test files of the vets-website repository. These updates to the test references did not break any unit or integration tests, as they were in many cases part of canned API responses and not used in any test assertions.
 
 Certain test references to `sandbox-api.va.gov` and `api.va.gov` did not require any changes because these reference endpoints will still be served by the Lighthouse API. **Example**: `health-care-questionnaire` application (not used in Production.)
@@ -77,9 +78,19 @@ Certain test references to `sandbox-api.va.gov` and `api.va.gov` did not require
 Parameterizing the API URL was done where possible. Setting the API_URL constant as an environment variable will ensure that unit specs that check for the variable value will pass before and after changing the configured API URL to the new *platform-ap.va.gov hostname.
 
 To prevent the future use of *api.va.gov in test files, the Release Tools Team should add custom linting rules that instruct users to use the new API URLs.
+&nbsp;
+&nbsp;
+#### **Diagram: New Production State with vets-api in BRD and Lighthouse/Kong**
 
+![Prod-release-state-BRD-Kong](https://user-images.githubusercontent.com/1426601/187307838-1ba75418-49e9-479c-8c85-89e8117751eb.png)
+&nbsp;
+&nbsp;
+#### **Diagram: Future Production State with vets-api in EKS and Lighthouse/Apigee**
+
+![Prod-release-state-EKS-Apigee](https://user-images.githubusercontent.com/1426601/187308803-f87cd357-d3ba-497a-94c6-ea792769ee6a.png)
+&nbsp;
+&nbsp;
 ### Pre-Release Tasks
-_TBD. Outstanding vets-api settings changes._
 
 #### **Coordination**
   - Kickoff Meeting to discuss team roles and responsibilities:
@@ -121,12 +132,6 @@ All systems will need to be deployed and tested in Staging prior to a Production
   - Identity Team works with IAM authentication partners to prepare a rollback plan for reverting auth callback changes. 
   - Release Tools Team prepares a rollback PR and build.
 
-The following authentication settings will need to be updated from *api.va.gov to *platform-api.va.gov:
-  - `idme > redirect_uri`
-  - `logingov > inherited_proofing_redirect_uri`
-  - `logingov > redirect_uri`
-  - `saml_ssoe > callback_url`
-
 **Step 2** (Coordinated release of vets-api and vets-website repositories in lower environments)
   - Broadcast an internal notification that Staging may be disrupted.
   - Site Reliability Engineering notified of impending deployment to Staging.
@@ -134,6 +139,11 @@ The following authentication settings will need to be updated from *api.va.gov t
   - In parallel:
     - The IAM team updates their own API callback URLs for Dev and Staging.
     - The Identity Team updates the vets-api authentication URLs for Dev and Staging. 
+    - The following authentication settings will need to be updated from *api.va.gov to *platform-api.va.gov:
+      - `idme > redirect_uri`
+      - `logingov > inherited_proofing_redirect_uri`
+      - `logingov > redirect_uri`
+      - `saml_ssoe > callback_url`
   - Release Tools Team updates globally configured API URL for vets-website for Dev and Staging.
   - vets-website repo:
     - PRs merged into the main branch are automatically built and deployed to both dev and staging. 
@@ -145,7 +155,6 @@ The following authentication settings will need to be updated from *api.va.gov t
     - The build step takes ~30 minutes, but can be run separately if needed.
     - The deploy step is fast.
   - Based on Pre-Release coordination research, trigger the deployment of both vets-api and vets-website so that they finish at approximately the same time. **Note**: Authentication flows may not work correctly until both applications have been fully deployed.
-
 
 
 **Step 3** (QA in Staging)
@@ -168,6 +177,9 @@ The following authentication settings will need to be updated from *api.va.gov t
   - Release Tools Team triggers vets-website deploy manually. The built-in pause in the manual release will need to be approved to resume the deployment after the Build and Release steps are finished.
   - Based on Pre-Release coordination research, trigger the deployment of both vets-api and vets-website so that they finish at approximately the same time.
   - All teams QA/UAT Production for issues.  
+
+**Coordinated Production Release Flow**
+
 ![staggered-deploy](https://user-images.githubusercontent.com/30317/186273089-4d101052-0166-4fde-aef5-d29214b866b2.png)
 
 

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -95,7 +95,6 @@ To prevent the future use of *api.va.gov in test files, the Release Tools Team s
 ### Pre-Release Tasks
 
 #### **Coordination**
-While the Lighthouse team currently doesn't have a fixed timeline for their migration to Apigee, we propose that the transition of VA.gov to the new hostname, platform-api.va.gov, should occur as soon as is feasible. This would ensure that the independence of VA.gov from the Lighthouse domain and infrastructure has been achieved and tested in production. 
 
   - Kickoff Meeting to discuss team roles and responsibilities:
     - Release Plan timeline.
@@ -121,12 +120,23 @@ While the Lighthouse team currently doesn't have a fixed timeline for their migr
 
 
 ### Release Steps
-Due to the interdependence of API calls made from VA.gov and authentication cookies set by vets-api, the deployment of the new *platform-api.va.gov hostname will require the coordinated releases of vets-api and vets-website. 
+Due to the interdependence of API calls made from VA.gov and authentication cookies set by vets-api, the deployment of the new *platform-api.va.gov hostname will require the coordinated releases of vets-api and vets-website or VA.gov. 
+
+vets-api sets an `api_session` cookie, whose domain is tied to the currently configured authentication callback URL. It is essential that the cookie domain set by vets-api matches the API URL that VA.gov uses to ensure that the browser correctly sends the authentication cookie to support authenticated API requests. A mismatch between the domains set in the cookie and used by VA.gov would cause a disruption in authentication behavior.
+
+The following options for obviating the need to coordinate the API URLs used by VA.gov and vets-api were considered:
+1. Have multiple SAML authentication callbacks configured at a time, which would allow to at least side-step the need to coordinate these changes with the IAM Team. However, this is not possible in the case of SAML, unlike some other auth providers.
+2. Set up an extra internal redirect between the auth callback and the final redirect to www.va.gov that would switch the domain back to whatever the VA.gov was expecting, and decouple these two things. This would require some prototyping in dev to fully assess.
+3. Use a domain wildcard for the cookie, i.e. one for \*.va.gov, in which case the browser would send the cookie for subsequent requests to _any_ va.gov subdomain. This might require some extra manipulation of the cookie name to account for different environments, e.g. `api-session-dev` for `dev-platform-api.va.gov`.
+
+Currently, we are working under the assumption that the change to the new hostname will be performed in a coordinated fashion between VA.gov and vets-api.
 
 All systems will need to be deployed and tested in Staging prior to a Production deployment.
 
 
 #### **Proposed Release Sequence:**
+
+While the Lighthouse team currently doesn't have a fixed timeline for their migration to Apigee, we propose that the transition of VA.gov to the new hostname, platform-api.va.gov, should occur as soon as is feasible. This would ensure that the independence of VA.gov from the Lighthouse domain and infrastructure has been achieved and tested in production. 
 
 **Step 1** (Rollback preparation)
   - Identity Team works with IAM authentication partners to prepare a rollback plan for reverting auth callback changes. 

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -196,7 +196,9 @@ At this time the Lighthouse team is working to transition to using the new Apige
 
 
 #### **Infrastructure Team**
-  - Removes api.va.gov references from the revProxy.
+  - Removes api.va.gov references from the revProxy. This should only happen once Apigee has been successfully set up as a new API gateway and fully owns the api.va.gov domains.
+  - While the revProxy still handles the api.va.gov domain, ensures that new rules added to the `nginx_api_server.conf` file get replicated in `ngix_new_api_server.conf`.
+  - Prevents new references to api.va.gov to be added to the vets-api config files `*-settings.local.yml.j2` and their EKS counterparts. 
   - **Note:** At this time only the Dev website is in EKS. As other environments migrate to EKS, routing configurations will need to be updated and release timing will need to be re-evaluated.
 
     Reference: [Enabling new *platform-api.va.gov domains in EKS](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263351375).
@@ -225,3 +227,5 @@ At this time the Lighthouse team is working to transition to using the new Apige
   - [Remapped vets-api settings](https://docs.google.com/spreadsheets/d/111t6f4V3eCVkaKoBIxXi54_HlkPT-54qKShfRjl-iMs/edit#gid=2101280441) (Google Sheet)
   - [Enabling new *platform-api.va.gov domains in EKS](https://vfs.atlassian.net/wiki/spaces/CLOUD/pages/2263351375) (Confluence)
   - [New Domain to Serve vets-api](https://vfs.atlassian.net/wiki/spaces/ECP/pages/2221572288/2022-06-06+New+domain+to+serve+vets-api) (ADR/Confluence)
+  - [Original Explainer Doc on VA.gov <=> Lighthouse overlap](https://vfs.atlassian.net/wiki/spaces/ECP/pages/1907523684/Explainer+-+VA.gov-Lighthouse+Overlap) (Confluence)
+  - [RFC on domain name decision](https://github.com/department-of-veterans-affairs/va.gov-team/discussions/39068) (Github)

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -84,12 +84,12 @@ To prevent the future use of *api.va.gov in test files, the Release Tools Team s
 &nbsp;
 #### **Diagram: New Production State with vets-api in BRD and Lighthouse/Kong**
 
-![Prod-release-state-BRD-Kong](https://user-images.githubusercontent.com/1426601/187307838-1ba75418-49e9-479c-8c85-89e8117751eb.png)
+![Prod-release-state-BRD-Kong](https://user-images.githubusercontent.com/1426601/187929311-0a5cac3b-115a-445b-aab2-8e7e7cbae419.svg)
 &nbsp;
 &nbsp;
 #### **Diagram: Future Production State with vets-api in EKS and Lighthouse/Apigee**
 
-![Prod-release-state-EKS-Apigee](https://user-images.githubusercontent.com/1426601/187308803-f87cd357-d3ba-497a-94c6-ea792769ee6a.png)
+![Prod-release-state-EKS-Apigee](https://user-images.githubusercontent.com/1426601/187929499-5974103b-3d20-422c-bd1a-98d6541f5451.svg)
 &nbsp;
 &nbsp;
 ### Pre-Release Tasks
@@ -190,7 +190,7 @@ While the Lighthouse team currently doesn't have a fixed timeline for their migr
 
 **Coordinated Production Release Flow**
 
-![staggered-deploy](https://user-images.githubusercontent.com/30317/186273089-4d101052-0166-4fde-aef5-d29214b866b2.png)
+![Staggered Deploy](https://user-images.githubusercontent.com/1426601/187937646-f3b5048f-e710-4a34-82c8-1a327de01136.svg)
 
 
 ### Post-Release Tasks

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -14,7 +14,9 @@ Vets-api and Lighthouse currently share the same API endpoint: api.va.gov. In th
 
 ## **Motivation**
 
-The product goals and technical infrastructures of Lighthouse and VA.gov have diverged over time. Sharing the api.va.gov hostname is no longer feasible. In particular, Lighthouse wants to re-architect to use an Apigee API gateway hosted in Google Cloud (GCP). There's no reason for all VA.gov traffic to route through this gateway or through GCP. Because Lighthouse has a large number of API consumers, most of whom are external to VA, they have priority for continuing to use api.va.gov. VA.gov will transition to a new API hostname.
+The product goals and technical infrastructures of Lighthouse and VA.gov have diverged over time. The two projects share the same cloud infrastructure and  have a common domain - api.va.gov. This tight coupling complicates configuration changes, debugging, and error management. Making changes to infrastructure components, such as the reverse or the forward proxy, requires extensive coordination between teams. It is also not a trivial task to determine the target of requests involved in different error alerts, which often delays their resolution. 
+
+However, one of the main reasons in hastening the separation of Lighthouse and the VA.gov was the desire of the Lighthouse team to change the technology of their API gateway from Kong to Apigee, and to move this infrastructure component into GCP, a new cloud environment. Such a change would have caused all VA.gov traffic to also be routed through this new API gateway, which would not have been very efficient from a networking point of view. Because Lighthouse has a large number of API consumers, most of whom are external to VA, they have priority for continuing to use the domain api.va.gov. As such, VA.gov will transition to a new API hostname.
 
 
 ### New hostname for vets-api
@@ -93,6 +95,7 @@ To prevent the future use of *api.va.gov in test files, the Release Tools Team s
 ### Pre-Release Tasks
 
 #### **Coordination**
+While the Lighthouse team currently doesn't have 
   - Kickoff Meeting to discuss team roles and responsibilities:
     - Release Plan timeline.
     - Rollback plan.

--- a/rfc/2022/2022-08-23_CIT_hostnames.md
+++ b/rfc/2022/2022-08-23_CIT_hostnames.md
@@ -117,6 +117,9 @@ To prevent the future use of *api.va.gov in test files, the Release Tools Team s
 
 #### **Release Tools Team**
   - Adds linting rules to prevent use of the api.va.gov hostname.
+  
+#### **VA Virtual Agent Team**
+  - Made aware of upcoming hostname change, as they extract the value of the session cookie to make authenticated requests to vets-api
 
 
 ### Release Steps


### PR DESCRIPTION
This document outlines the work of the Cloud Isolation Team to prepare for the migration of the Lighthouse API and to transition to a set of new domains, `platform-api.va.gov`, that will exclusively serve vets-api.

## RFC Title
Hostname Transition Release Plan

## RFC Preview Link
[Preview link](https://github.com/department-of-veterans-affairs/va.gov-platform-architecture/blob/5bb30c4d3cf74ef49b856f4bd02b3ab24b85a01e/rfc/2022/2022-08-23_CIT_hostnames.md) 

## Comment Period End Date
09-08-2022
